### PR TITLE
Feat/optional python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "indoc",
+ "inventory",
  "libc",
  "memoffset",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,9 @@ strum_macros = "0.27.2"
 
 [dependencies.pyo3]
 version = "0.26.0"
-features = ["abi3-py38"]  # "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8.
+features = ["abi3-py38", "multiple-pymethods"]  # "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8.
+optional = true
+
+[features]
+default = ["python"]
+python = ["dep:pyo3"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ fn main() {
 }
 ```
 
+### Disable Python Bindings
+
+The `python` feature flag is enabled by default. In projects that don't interoperate with Python, the Python bindings can be disabled by turning off default features. In `Cargo.toml`:
+
+```toml
+[dependencies]
+qmk-via-api = { version = "0.3.0", default-features = false }
+```
+
 ## Python
 
 Install with pip:

--- a/src/api.rs
+++ b/src/api.rs
@@ -97,12 +97,6 @@ impl From<&str> for Error {
     }
 }
 
-// impl From<Error> for String {
-//     fn from(error: Error) -> Self {
-//         error.0
-//     }
-// }
-
 impl KeyboardApi {
     pub fn new(vid: u16, pid: u16, usage_page: u16) -> Result<KeyboardApi, Error> {
         let api = HidApi::new().map_err(|e| format!("Error: {e}"))?;

--- a/src/api_commands.rs
+++ b/src/api_commands.rs
@@ -1,6 +1,7 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ViaCommandId {
     GetProtocolVersion = 0x01,
@@ -26,7 +27,7 @@ pub enum ViaCommandId {
     DynamicKeymapSetEncoder = 0x15,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ViaChannelId {
     IdCustomChannel = 0,
@@ -37,14 +38,14 @@ pub enum ViaChannelId {
     IdQmkLedMatrixChannel = 5,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ViaQmkBacklightValue {
     IdQmkBacklightBrightness = 1,
     IdQmkBacklightEffect = 2,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ViaQmkRgblightValue {
     IdQmkRgblightBrightness = 1,
@@ -53,7 +54,7 @@ pub enum ViaQmkRgblightValue {
     IdQmkRgblightColor = 4,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ViaQmkRgbMatrixValue {
     IdQmkRgbMatrixBrightness = 1,
@@ -62,7 +63,7 @@ pub enum ViaQmkRgbMatrixValue {
     IdQmkRgbMatrixColor = 4,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ViaQmkLedMatrixValue {
     IdQmkLedMatrixBrightness = 1,
@@ -70,7 +71,7 @@ pub enum ViaQmkLedMatrixValue {
     IdQmkLedMatrixEffectSpeed = 3,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ViaQmkAudioValue {
     IdQmkAudioEnable = 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
-use pyo3::prelude::*;
-
 pub mod api;
 pub mod api_commands;
 pub mod keycodes;
 pub mod scan;
 pub mod utils;
 
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg(feature = "python")]
 #[pymodule]
 fn qmk_via_api(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<api::KeyboardApi>()?;

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,34 +1,30 @@
 use hidapi::HidApi;
+
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 const VIA_USAGE_PAGE: u16 = 0xff60;
 
 /// Information about a connected VIA-compatible keyboard.
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug)]
 pub struct KeyboardDeviceInfo {
     /// USB vendor ID
-    #[pyo3(get)]
     pub vendor_id: u16,
     /// USB product ID
-    #[pyo3(get)]
     pub product_id: u16,
     /// HID usage page (expected to be 0xFF60 for VIA)
-    #[pyo3(get)]
     pub usage_page: u16,
     /// Optional manufacturer string
-    #[pyo3(get)]
     pub manufacturer: Option<String>,
     /// Optional product string
-    #[pyo3(get)]
     pub product: Option<String>,
     /// Optional serial number string
-    #[pyo3(get)]
     pub serial_number: Option<String>,
 }
 
 /// Scan for connected VIA keyboards.
-#[pyfunction]
+#[cfg_attr(feature = "python", pyfunction)]
 pub fn scan_keyboards() -> Vec<KeyboardDeviceInfo> {
     let api = match HidApi::new() {
         Ok(a) => a,
@@ -37,15 +33,15 @@ pub fn scan_keyboards() -> Vec<KeyboardDeviceInfo> {
 
     api.device_list()
         .filter(|d| d.usage_page() == VIA_USAGE_PAGE)
-        .filter_map(|d| {
-            Some(KeyboardDeviceInfo {
+        .map(|d| {
+            KeyboardDeviceInfo {
                 vendor_id: d.vendor_id(),
                 product_id: d.product_id(),
                 usage_page: d.usage_page(),
                 manufacturer: d.manufacturer_string().map(|s| s.to_string()),
                 product: d.product_string().map(|s| s.to_string()),
                 serial_number: d.serial_number().map(|s| s.to_string()),
-            })
+            }
         })
         .collect()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,7 +32,7 @@ pub fn shift_buffer_to_16_bit(buffer: &[u8]) -> Vec<u16> {
     shifted_buffer
 }
 
-pub fn shift_buffer_from_16_bit(buffer: &Vec<u16>) -> Vec<u8> {
+pub fn shift_buffer_from_16_bit(buffer: &[u16]) -> Vec<u8> {
     let mut flattened = Vec::new();
     for value in buffer.iter() {
         let (hi, lo) = shift_from_16_bit(*value);


### PR DESCRIPTION
The new feature flag (`python`) allows turning off the python bindings. This may be desirable in projects that don't interoperate with Python.

To preserve the existing behavior, if the `python` feature is not explicitly disabled, it remains on by default.

* annotate pyo3 references to allow conditional compilation
* address minor linting issues
