### PR TITLE
Implement std::error::Error for custom error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,11 @@ impl From<HidError> for Error {
     }
 }
 
+// This makes it possible to use the `?` operator
+// with `Error` in functions that return `Result<T, Error>`.
+// We also need this for compatibility with crates like Anyhow.
+impl std::error::Error for Error {}
+
 #[cfg(feature = "python")]
 impl From<Error> for pyo3::PyErr {
     fn from(err: Error) -> Self {


### PR DESCRIPTION
This PR adds an implementation of the `std::error::Error` trait for the `Error` type, improving error handling and compatibility with crates like `anyhow` which allows the use of the `?` operator with `Error` in functions returning `Result<T, Error>`.