### PR TITLE
Check HID access permissions before scanning

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,9 +6,12 @@ use crate::api_commands::ViaCommandId;
 
 pub type Result<T> = core::result::Result<T, Error>;
 
+pub const MAYBE_PERMISSION_DENIED_MESSAGE: &str = "No HID devices were visible through hidapi. This can mean no HID devices are connected, but it can also indicate that this process does not have permission to enumerate HID devices. On Linux, check that the user has access to hidraw devices or install the appropriate udev rules for the keyboard.";
+
 #[derive(Debug)]
 pub enum Error {
     Hid(String),
+    MaybePermissionDenied(String),
     BadCommandResponse(ViaCommandId),
     SendCommand(ViaCommandId, String),
     NoSuchKeyboard {
@@ -33,6 +36,10 @@ impl Error {
             actual,
             context,
         }
+    }
+
+    pub fn maybe_permission_denied() -> Self {
+        Error::MaybePermissionDenied(MAYBE_PERMISSION_DENIED_MESSAGE.to_string())
     }
 }
 
@@ -66,6 +73,7 @@ impl std::fmt::Display for Error {
                 cmd
             )),
             Error::InvalidArgument(arg) => f.write_fmt(format_args!("invalid argument: {}", arg)),
+            Error::MaybePermissionDenied(msg) => f.write_str(msg),
             _ => Debug::fmt(&self, f),
         }
     }
@@ -82,6 +90,9 @@ impl From<Error> for pyo3::PyErr {
     fn from(err: Error) -> Self {
         match err {
             Error::Hid(msg) => pyo3::PyErr::new::<crate::HidError, _>(msg),
+            Error::MaybePermissionDenied(msg) => {
+                pyo3::PyErr::new::<crate::MaybePermissionDeniedError, _>(msg)
+            }
             Error::NoSuchKeyboard {
                 vid,
                 pid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,5 +59,6 @@ fn qmk_via_api(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
         _py.get_type::<InvalidArgumentError>(),
     )?;
     m.add_function(wrap_pyfunction!(scan::scan_keyboards, m)?)?;
+    m.add_function(wrap_pyfunction!(scan::check_hid_permissions, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ create_exception!(qmk_via_api, QmkViaError, PyException);
 #[cfg(feature = "python")]
 create_exception!(qmk_via_api, HidError, QmkViaError);
 #[cfg(feature = "python")]
+create_exception!(qmk_via_api, MaybePermissionDeniedError, QmkViaError);
+#[cfg(feature = "python")]
 create_exception!(qmk_via_api, DeviceNotFoundError, QmkViaError);
 #[cfg(feature = "python")]
 create_exception!(qmk_via_api, UnsupportedProtocolError, QmkViaError);
@@ -38,6 +40,10 @@ fn qmk_via_api(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<scan::KeyboardDeviceInfo>()?;
     m.add("QmkViaError", _py.get_type::<QmkViaError>())?;
     m.add("HidError", _py.get_type::<HidError>())?;
+    m.add(
+        "MaybePermissionDeniedError",
+        _py.get_type::<MaybePermissionDeniedError>(),
+    )?;
     m.add("DeviceNotFoundError", _py.get_type::<DeviceNotFoundError>())?;
     m.add(
         "UnsupportedProtocolError",

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -48,15 +48,13 @@ pub fn scan_keyboards() -> Result<Vec<KeyboardDeviceInfo>> {
 // where users may need to set up udev rules
 // to access HID devices without root.
 #[cfg_attr(feature = "python", pyfunction)]
-pub fn check_hid_permissions() -> Result<HidApi> {
+pub fn check_hid_permissions() -> Result<()> {
     match HidApi::new() {
         Ok(api) => {
             if api.device_list().count() == 0 {
-                return Err(Error::Hid(
-                    "No HID devices found. This may indicate a permissions issue.".to_string(),
-                ));
+                return Err(Error::maybe_permission_denied());
             }
-            Ok(api)
+            Ok(())
         }
         Err(e) => Err(Error::Hid(format!("Failed to initialize HID API: {}", e))),
     }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,4 +1,4 @@
-use crate::Result;
+use crate::{Error, Result};
 use hidapi::HidApi;
 
 #[cfg(feature = "python")]
@@ -27,7 +27,7 @@ pub struct KeyboardDeviceInfo {
 /// Scan for connected VIA keyboards.
 #[cfg_attr(feature = "python", pyfunction)]
 pub fn scan_keyboards() -> Result<Vec<KeyboardDeviceInfo>> {
-    let api = HidApi::new()?;
+    let api = check_hid_permissions()?;
 
     Ok(api
         .device_list()
@@ -41,4 +41,23 @@ pub fn scan_keyboards() -> Result<Vec<KeyboardDeviceInfo>> {
             serial_number: d.serial_number().map(|s| s.to_string()),
         })
         .collect())
+}
+
+/// Check for HID permissions.
+// This is especially relevant on Linux,
+// where users may need to set up udev rules
+// to access HID devices without root.
+#[cfg_attr(feature = "python", pyfunction)]
+pub fn check_hid_permissions() -> Result<HidApi> {
+    match HidApi::new() {
+        Ok(api) => {
+            if api.device_list().count() == 0 {
+                return Err(Error::Hid(
+                    "No HID devices found. This may indicate a permissions issue.".to_string(),
+                ));
+            }
+            Ok(api)
+        }
+        Err(e) => Err(Error::Hid(format!("Failed to initialize HID API: {}", e))),
+    }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -43,19 +43,63 @@ pub fn scan_keyboards() -> Result<Vec<KeyboardDeviceInfo>> {
         .collect())
 }
 
+fn try_open_device(api: &HidApi, info: &KeyboardDeviceInfo) -> Result<()> {
+    let device = api
+        .device_list()
+        .find(|d| {
+            d.usage_page() == VIA_USAGE_PAGE
+                && d.vendor_id() == info.vendor_id
+                && d.product_id() == info.product_id
+        })
+        .ok_or(Error::NoSuchKeyboard {
+            vid: info.vendor_id,
+            pid: info.product_id,
+            usage_page: info.usage_page,
+        })?;
+
+    device.open_device(api)?;
+    Ok(())
+}
+
 /// Check for HID permissions.
 // This is especially relevant on Linux,
 // where users may need to set up udev rules
 // to access HID devices without root.
 #[cfg_attr(feature = "python", pyfunction)]
-pub fn check_hid_permissions() -> Result<()> {
-    match HidApi::new() {
-        Ok(api) => {
-            if api.device_list().count() == 0 {
-                return Err(Error::maybe_permission_denied());
+pub fn check_hid_permissions(filter: Option<KeyboardDeviceInfo>) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        match HidApi::new() {
+            Ok(api) => {
+                if api.device_list().count() == 0 {
+                    return Err(Error::maybe_permission_denied());
+                }
+                if let Some(f) = filter {
+                    try_open_device(&api, &f)?;
+                }
+                Ok(())
             }
-            Ok(())
+            Err(e) => Err(Error::Hid(format!("Failed to initialize HID API: {}", e))),
         }
-        Err(e) => Err(Error::Hid(format!("Failed to initialize HID API: {}", e))),
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    {
+        match HidApi::new() {
+            Ok(api) => {
+                if let Some(f) = filter {
+                    try_open_device(&api, &f)?;
+                }
+                Ok(())
+            }
+            Err(e) => Err(Error::Hid(format!("Failed to initialize HID API: {}", e))),
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        Err(Error::UnsupportedFeature(
+            "HID permission checking is not implemented for this platform",
+        ))
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -27,7 +27,7 @@ pub struct KeyboardDeviceInfo {
 /// Scan for connected VIA keyboards.
 #[cfg_attr(feature = "python", pyfunction)]
 pub fn scan_keyboards() -> Result<Vec<KeyboardDeviceInfo>> {
-    let api = check_hid_permissions()?;
+    let api = HidApi::new()?;
 
     Ok(api
         .device_list()

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -62,9 +62,9 @@ fn try_open_device(api: &HidApi, info: &KeyboardDeviceInfo) -> Result<()> {
 }
 
 /// Check for HID permissions.
-// This is especially relevant on Linux,
-// where users may need to set up udev rules
-// to access HID devices without root.
+/// On linux, this checks if the HID device list is empty and optionally tries to open a specific device to verify permissions.
+/// On windows and macOS, it simply checks if the HID API can be initialized and optionally tries to open a specific device.
+/// On unsupported platforms, it returns an error indicating that the feature is not implemented.
 #[cfg_attr(feature = "python", pyfunction)]
 pub fn check_hid_permissions(filter: Option<KeyboardDeviceInfo>) -> Result<()> {
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
This pull request improves the detection and handling of HID device permission issues, particularly on Linux systems, by adding a new permission check and updating how HID devices are scanned.

**How:**

* Added a new function `check_hid_permissions` in `src/scan.rs` to initialize the HID API and return a user-friendly error if no HID devices are found, which may indicate a permissions issue.
* Updated `scan_keyboards` to use `check_hid_permissions` instead of directly calling `HidApi::new()`, ensuring permission errors are caught and reported early.