### PR TITLE
Add timeout functionality and error handling to public methods

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -63,6 +63,7 @@ fn hid_command_on_device(
     device: &hidapi::HidDevice,
     command: ViaCommandId,
     bytes: Vec<u8>,
+    timeout_ms: Option<i32>,
 ) -> Result<Vec<u8>> {
     let mut command_bytes: Vec<u8> = vec![command as u8];
     command_bytes.extend(bytes);
@@ -70,7 +71,7 @@ fn hid_command_on_device(
     hid_send_on_device(device, command_bytes.clone())
         .map_err(|send_err| Error::SendCommand(command, send_err.to_string()))?;
 
-    let buffer = hid_read_on_device(device)?;
+    let buffer = hid_read_on_device(device, timeout_ms)?;
     if buffer.starts_with(&command_bytes) {
         Ok(buffer)
     } else {
@@ -78,9 +79,13 @@ fn hid_command_on_device(
     }
 }
 
-fn hid_read_on_device(device: &hidapi::HidDevice) -> Result<Vec<u8>> {
+fn hid_read_on_device(device: &hidapi::HidDevice, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
     let mut buffer = vec![0; RAW_EPSIZE];
-    device.read(&mut buffer)?;
+    if let Some(timeout) = timeout_ms {
+        device.read_timeout(&mut buffer, timeout)?;
+    } else {
+        device.read(&mut buffer)?;
+    }
     Ok(buffer)
 }
 
@@ -162,7 +167,7 @@ impl KeyboardApi {
             })?
             .open_device(&api)?;
 
-        let protocol_version = Self::read_protocol_version(&device)?;
+        let protocol_version = Self::read_protocol_version(&device, timeout_ms)?;
         Ok(KeyboardApi {
             device,
             protocol_version,
@@ -182,8 +187,9 @@ impl KeyboardApi {
         )
     }
 
-    fn read_protocol_version(device: &hidapi::HidDevice) -> Result<u16> {
-        let buffer = hid_command_on_device(device, ViaCommandId::GetProtocolVersion, vec![])?;
+    fn read_protocol_version(device: &hidapi::HidDevice, timeout_ms: Option<i32>) -> Result<u16> {
+        let buffer =
+            hid_command_on_device(device, ViaCommandId::GetProtocolVersion, vec![], timeout_ms)?;
         Ok(utils::shift_to_16_bit(buffer[1], buffer[2]))
     }
 }
@@ -192,12 +198,12 @@ impl KeyboardApi {
 impl KeyboardApi {
     /// Sends a raw HID command prefixed with the command byte and returns the response if successful.
     pub fn hid_command(&self, command: ViaCommandId, bytes: Vec<u8>) -> Result<Vec<u8>> {
-        hid_command_on_device(&self.device, command, bytes)
+        hid_command_on_device(&self.device, command, bytes, self.timeout_ms)
     }
 
     /// Reads from the HID device. Returns None if the read fails.
     pub fn hid_read(&self) -> Result<Vec<u8>> {
-        hid_read_on_device(&self.device)
+        hid_read_on_device(&self.device, self.timeout_ms)
     }
 
     /// Sends a raw HID command prefixed with the command byte. Returns None if the send fails.

--- a/src/api.rs
+++ b/src/api.rs
@@ -117,25 +117,35 @@ fn hid_send_on_device(device: &hidapi::HidDevice, bytes: Vec<u8>) -> Result<()> 
 pub struct KeyboardApi {
     device: hidapi::HidDevice,
     protocol_version: u16,
+    timeout_ms: Option<i32>,
 }
 
 #[cfg(feature = "python")]
 #[pymethods]
 impl KeyboardApi {
     #[new]
-    pub fn py_new(vid: u16, pid: u16, usage_page: u16) -> Result<Self> {
-        KeyboardApi::new(vid, pid, usage_page)
+    pub fn py_new(vid: u16, pid: u16, usage_page: u16, timeout_ms: Option<i32>) -> Result<Self> {
+        KeyboardApi::new(vid, pid, usage_page, timeout_ms)
     }
 
     #[classmethod]
     #[pyo3(name = "from_device")]
-    pub fn py_from_device(_cls: &Bound<'_, PyType>, device: &KeyboardDeviceInfo) -> Result<Self> {
-        KeyboardApi::from_device(device)
+    pub fn py_from_device(
+        _cls: &Bound<'_, PyType>,
+        device: &KeyboardDeviceInfo,
+        timeout_ms: Option<i32>,
+    ) -> Result<Self> {
+        KeyboardApi::from_device(device, timeout_ms)
     }
 }
 
 impl KeyboardApi {
-    pub fn new(vid: u16, pid: u16, usage_page: u16) -> Result<KeyboardApi> {
+    pub fn new(
+        vid: u16,
+        pid: u16,
+        usage_page: u16,
+        timeout_ms: Option<i32>,
+    ) -> Result<KeyboardApi> {
         let api = HidApi::new()?;
 
         let device = api
@@ -156,11 +166,20 @@ impl KeyboardApi {
         Ok(KeyboardApi {
             device,
             protocol_version,
+            timeout_ms,
         })
     }
 
-    pub fn from_device(device: &KeyboardDeviceInfo) -> Result<KeyboardApi> {
-        Self::new(device.vendor_id, device.product_id, device.usage_page)
+    pub fn from_device(
+        device: &KeyboardDeviceInfo,
+        timeout_ms: Option<i32>,
+    ) -> Result<KeyboardApi> {
+        Self::new(
+            device.vendor_id,
+            device.product_id,
+            device.usage_page,
+            timeout_ms,
+        )
     }
 
     fn read_protocol_version(device: &hidapi::HidDevice) -> Result<u16> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -196,6 +196,21 @@ impl KeyboardApi {
 
 #[cfg_attr(feature = "python", pymethods)]
 impl KeyboardApi {
+    /// Sets the read command timeout in milliseconds.
+    /// If set, the commands depend on HID reads timeout after `timeout_ms`
+    /// and return a HIDError.
+    ///
+    /// Set -1 for blocking wait
+    pub fn set_timeout(&mut self, timeout_ms: i32) {
+        self.timeout_ms = Some(timeout_ms);
+    }
+
+    /// Disable the timeouts enforced on the HID reads,
+    /// meaning the commands will block while waiting a HID response.
+    pub fn disable_timeout(&mut self) {
+        self.timeout_ms = None;
+    }
+
     /// Sends a raw HID command prefixed with the command byte and returns the response if successful.
     pub fn hid_command(&self, command: ViaCommandId, bytes: Vec<u8>) -> Result<Vec<u8>> {
         hid_command_on_device(&self.device, command, bytes, self.timeout_ms)


### PR DESCRIPTION
This pull request adds new timeout error variants to the API for HID operations.

Also:

* Added new `Timeout` variant to the `Error` enum in `src/error.rs` to represent HID read timeouts.
* Updated the `Display` implementation for `Error` to provide a user-friendly message for the new `Timeout` variant.
* Modified the `From<Error> for pyo3::PyErr` implementation to convert the new `Timeout` error to a Python exception with an appropriate message.